### PR TITLE
Fix small typo on db.json

### DIFF
--- a/db.json
+++ b/db.json
@@ -11,7 +11,7 @@
         "american cheese",
         "burger sauce",
         "french mustard",
-        "pickes",
+        "pickles",
         "onion",
         "lettuce"
       ],


### PR DESCRIPTION
Is just an irrelevant typo "pickles" for "pickes" in "id": 0.